### PR TITLE
fix(website): literal public Sentry DSN fallback (CI env not surfacing)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -106,9 +106,14 @@ const nextConfig = {
     NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: process.env.VERCEL_GIT_COMMIT_SHA || "",
     NEXT_PUBLIC_VERCEL_ENV: process.env.VERCEL_ENV || "development",
 
-    // Sentry (must be listed here to be inlined into the client bundle in this
-    // project's build — NEXT_PUBLIC_* are not auto-inlined; see Firebase vars below)
-    NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN || "",
+    // Sentry. Must be listed here to be inlined into the client bundle in this
+    // project's build (NEXT_PUBLIC_* are not auto-inlined; see Firebase vars below).
+    // The Vercel-provided env var is not reliably present at `vercel build` time in
+    // CI, so we fall back to the literal public DSN (a DSN is a public, client-side
+    // key — safe to commit; the secret is the auth token, which is never here).
+    NEXT_PUBLIC_SENTRY_DSN:
+      process.env.NEXT_PUBLIC_SENTRY_DSN ||
+      "https://4d02959a50a9dbd2e64269fcf0643292@o4511629316980736.ingest.us.sentry.io/4511632294871040",
     NEXT_PUBLIC_SENTRY_ENV: process.env.NEXT_PUBLIC_SENTRY_ENV || process.env.VERCEL_ENV || "production",
 
     // Support both NEXT_PUBLIC_* (Next.js standard) and VITE_* (legacy) prefixes


### PR DESCRIPTION
Follow-up to #148. The env-block reference still inlined empty because the Vercel env var isn't in process.env at `vercel build` time in CI. DSNs are public; hardcode the public DSN as the fallback so Sentry actually initializes. Will verify with a forced-error ingest check post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)